### PR TITLE
Revert "Remove feed_info test as its not in the sample data"

### DIFF
--- a/tests/read_gtfs.rs
+++ b/tests/read_gtfs.rs
@@ -111,7 +111,6 @@ fn test_read_transfers() {
     }
 }
 
-/*
 #[test]
 fn test_read_feed_info() {
     let iter: GTFSIterator<_, FeedInfo> =
@@ -120,4 +119,3 @@ fn test_read_feed_info() {
         assert!(result.is_ok(), format!("{}", result.err().unwrap()));
     }
 }
-*/


### PR DESCRIPTION
This reverts commit c2e13b1dc134bb5a64eecdc9b7967ac43dc43a10.

Commit 3e5b25e01184ac889cdcad05e77b8013b7bd5898 provides a
feed_info file for the test.